### PR TITLE
enhance kube-setup.sh to auto add to libvirt group

### DIFF
--- a/kube-setup.sh
+++ b/kube-setup.sh
@@ -59,6 +59,11 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/miniku
 sudo chmod +x minikube
 sudo mv minikube /usr/local/bin
 
+# adds current user to libvirt group
+echo adding `id -un` to the group 'libvirt'
+sudo usermod -aG libvirt `id -un`
+
+
 # start minikube
 minikube start --memory 4096 --vm-driver=kvm2
 


### PR DESCRIPTION
Couple of lines to prevent modify  script in order to add the user to `libvirt` group (as told in video 3.1).

Tested in Ubuntu 20.04. Hope this helps.